### PR TITLE
src/usr/bin: add btrfs support for Fedora variant

### DIFF
--- a/packaging/gce-disk-expand.spec
+++ b/packaging/gce-disk-expand.spec
@@ -20,7 +20,7 @@ License: Apache Software License
 Group: System Environment/Base
 URL: https://github.com/GoogleCloudPlatform/guest-diskexpand
 Source0: %{name}_%{version}.orig.tar.gz
-Requires: e2fsprogs, dracut, grep, util-linux, parted, gdisk
+Requires: e2fsprogs, dracut, grep, util-linux, parted, gdisk, awk, sed
 Conflicts: dracut-modules-growroot
 
 BuildArch: noarch

--- a/src/usr/bin/google_disk_expand
+++ b/src/usr/bin/google_disk_expand
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if ! root=$(findmnt -n -o SOURCE /) || [[ -z "$root" ]] ||
+if ! root=$(findmnt -nvr -o SOURCE /) || [[ -z "$root" ]] ||
   [[ ! -b "$root" ]]; then
   echo "Couldn't determine root device"
   exit 1
@@ -27,6 +27,28 @@ if ! fstype=$(findmnt -n -o FSTYPE /) || [[ -z "$fstype" ]]; then
 fi
 
 case "$fstype" in
+  btrfs*)                                                                                                                                                     
+    root_partition=$(mount | grep 'on \/ ' | awk '{print $1}')                                                                                                
+    root_device=$(echo ${root_partition} | sed s'/[0-9]//'g)                                                                                                  
+    echo "Unmounting /"
+    umount /
+    echo "Removing root paritition."
+    parted ${root_device} rm 4
+    echo "Recreating root partition to use all available space"
+    # df -m 
+    # /dev/sda5           9133   410      8250   5% /
+    parted ${root_device} mkpart primary btrfs 8250M 100%
+    echo "Running partition probe"
+    sync
+    partprobe
+    echo "Remounting root partition"
+    mount -o remount,rw ${root_partition}
+    echo "Increasing Btrfs file system size"
+    if ! out=$(btrfs filesystem resize max /); then
+      echo "Calling btrfs \"${root}\" failed: ${out}"
+      exit 1
+    fi
+    ;;
   ext*)
     if ! out=$(resize2fs "$root"); then
       echo "Calling resize2fs \"${root}\" failed: ${out}"


### PR DESCRIPTION
Fedora switched to the btrfs file system since Fedora-33, so it would be helpful to support that file system while resizing the root partition for GCP VMs.