### PR TITLE
Fix URL for Debian packages

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Google Cloud Team <gc-team@google.com>
 Build-Depends: debhelper (>= 10)
 Standards-Version: 3.9.8
-Homepage: https://github.com/GoogleCloudPlatform/compute-image-packages
+Homepage: https://github.com/GoogleCloudPlatform/guest-diskexpand
 
 Package: gce-disk-expand
 Architecture: all


### PR DESCRIPTION
A DEB package spec has the link to the old repo, while RPM is fine.
This PR fixes the URL.